### PR TITLE
t/8: Use Template class to bootstrap IconView.

### DIFF
--- a/src/icon/iconview.js
+++ b/src/icon/iconview.js
@@ -18,30 +18,26 @@ export default class IconView extends View {
 	constructor( model ) {
 		super( model );
 
-		this._createViewElement();
-	}
+		const bind = this.attributeBinder;
 
-	_createViewElement() {
-		// Note: Creating SVG icons with with Template class is not possible
-		// because of CSS limitations of document.createEleentNS–created elements.
-		const tmp = document.createElement( 'div' );
-
-		tmp.innerHTML =
-			`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="ck-icon ck-icon-left">
-				<use xlink:href="#ck-icon-${ this.model.icon }"></use>
-			</svg>`;
-
-		this.element = tmp.firstChild;
-
-		/**
-		 * An element which is responsible for displaying the right icon.
-		 *
-		 * @member {HTMLElement} ui.icon.IconView#svgUseElement
-		 */
-		this.svgUseElement = this.element.firstElementChild;
-
-		this.model.on( 'change:icon', ( evt, name, value ) => {
-			this.svgUseElement.setAttribute( 'xlink:href', `#ck-icon-${ value }` );
-		} );
+		this.template = {
+			tag: 'svg',
+			ns: 'http://www.w3.org/2000/svg',
+			attributes: {
+				class: 'ck-icon ck-icon-left'
+			},
+			children: [
+				{
+					tag: 'use',
+					ns: 'http://www.w3.org/2000/svg',
+					attributes: {
+						href: {
+							ns: 'http://www.w3.org/1999/xlink',
+							value: bind.to( 'icon', i => `#ck-icon-${ i }` )
+						}
+					}
+				}
+			]
+		};
 	}
 }

--- a/tests/iconview.js
+++ b/tests/iconview.js
@@ -7,11 +7,8 @@
 
 'use strict';
 
-import testUtils from '/tests/ckeditor5/_utils/utils.js';
 import IconView from '/ckeditor5/ui/icon/iconview.js';
 import Model from '/ckeditor5/ui/model.js';
-
-testUtils.createSinonSandbox();
 
 describe( 'IconView', () => {
 	let model, view;
@@ -24,36 +21,24 @@ describe( 'IconView', () => {
 	} );
 
 	describe( 'constructor', () => {
-		it( 'calls _createViewElement', () => {
-			const spy = testUtils.sinon.spy( IconView.prototype, '_createViewElement' );
-
-			view = new IconView( model );
-
-			expect( spy.calledOnce ).to.be.true;
-		} );
-	} );
-
-	describe( '_createViewElement', () => {
-		it( 'creates view.element', () => {
-			view._createViewElement();
-
+		it( 'creates element from template', () => {
 			expect( view.element.tagName ).to.be.equal( 'svg' );
 			expect( view.element.getAttribute( 'class' ) ).to.be.equal( 'ck-icon ck-icon-left' );
 		} );
+	} );
 
-		it( 'creates view.svgUseElement', () => {
-			view._createViewElement();
+	describe( '<svg> bindings', () => {
+		describe( 'xlink:href', () => {
+			it( 'reacts to model.icon', () => {
+				const svgUseElement = view.element.firstChild;
+				const svgHrefNs = 'http://www.w3.org/1999/xlink';
 
-			expect( view.svgUseElement.tagName ).to.be.equal( 'use' );
-			expect( view.svgUseElement.getAttribute( 'xlink:href' ) ).to.be.equal( '#ck-icon-foo' );
-		} );
+				expect( svgUseElement.getAttributeNS( svgHrefNs, 'href' ) ).to.be.equal( '#ck-icon-foo' );
 
-		it( 'creates model#change:icon binding', () => {
-			view._createViewElement();
+				model.icon = 'abc';
 
-			expect( view.svgUseElement.getAttribute( 'xlink:href' ) ).to.be.equal( '#ck-icon-foo' );
-			model.icon = 'abc';
-			expect( view.svgUseElement.getAttribute( 'xlink:href' ) ).to.be.equal( '#ck-icon-abc' );
+				expect( svgUseElement.getAttributeNS( svgHrefNs, 'href' ) ).to.be.equal( '#ck-icon-abc' );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #8.

Requires: 
- https://github.com/ckeditor/ckeditor5-ui/pull/21
- https://github.com/ckeditor/ckeditor5-theme-lark/pull/4
