### PR TITLE
Added `noText` option to ButtonView.

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -35,6 +35,12 @@ export default class Button extends Controller {
  */
 
 /**
+ * Whether the label of the button is hidden (e.g. button with icon only).
+ *
+ * @member {String} ui.button.ButtonModel#noText
+ */
+
+/**
  * Whether the button is "on" (e.g. some feature which this button represents is currently enabled).
  *
  * @member {Boolean} ui.button.ButtonModel#isOn

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -22,6 +22,9 @@ export default class ButtonView extends View {
 
 		const bind = this.bind;
 
+		// Set default value for `noText` property.
+		model.set( 'noText', !!model.noText );
+
 		this.template = new Template( {
 			tag: 'button',
 
@@ -29,13 +32,24 @@ export default class ButtonView extends View {
 				class: [
 					'ck-button',
 					bind.to( 'isEnabled', value => value ? 'ck-enabled' : 'ck-disabled' ),
-					bind.to( 'isOn', value => value ? 'ck-on' : 'ck-off' )
+					bind.to( 'isOn', value => value ? 'ck-on' : 'ck-off' ),
+					bind.if( 'noText', 'ck-button-notext' )
 				]
 			},
 
 			children: [
 				{
-					text: bind.to( 'label' )
+					tag: 'span',
+
+					attributes: {
+						class: [ 'ck-button__label' ]
+					},
+
+					children: [
+						{
+							text: bind.to( 'label' )
+						}
+					]
 				}
 			],
 

--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -22,9 +22,6 @@ export default class ButtonView extends View {
 
 		const bind = this.bind;
 
-		// Set default value for `noText` property.
-		model.set( 'noText', !!model.noText );
-
 		this.template = new Template( {
 			tag: 'button',
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -56,6 +56,7 @@ describe( 'ButtonView', () => {
 				expect( view.element.classList.contains( 'ck-button' ) ).to.be.true( 'ck-button' );
 				expect( view.element.classList.contains( 'ck-enabled' ) ).to.be.true( 'ck-enabled' );
 				expect( view.element.classList.contains( 'ck-off' ) ).to.be.true( 'ck-off' );
+				expect( view.element.classList.contains( 'ck-button-notext' ) ).to.be.false;
 			} );
 
 			it( 'reacts on model.isEnabled', () => {
@@ -68,6 +69,12 @@ describe( 'ButtonView', () => {
 				model.isOn = true;
 
 				expect( view.element.classList.contains( 'ck-on' ) ).to.be.true( 'ck-on' );
+			} );
+
+			it( 'reacts on model.noText', () => {
+				model.noText = true;
+
+				expect( view.element.classList.contains( 'ck-button-notext' ) ).to.be.true;
 			} );
 		} );
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -72,7 +72,7 @@ describe( 'ButtonView', () => {
 			} );
 
 			it( 'reacts on model.noText', () => {
-				model.noText = true;
+				model.set( 'noText', true );
 
 				expect( view.element.classList.contains( 'ck-button-notext' ) ).to.be.true;
 			} );

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -30,7 +30,7 @@ describe( 'ButtonView', () => {
 
 	describe( 'constructor', () => {
 		it( 'registers "children" region', () => {
-			expect( view.regions.get( 0 ).name ).to.be.equal( 'children' );
+			expect( view.regions.get( 0 ).name ).to.equal( 'children' );
 		} );
 
 		it( 'calls _setupIcon when "icon" in model', () => {
@@ -53,22 +53,22 @@ describe( 'ButtonView', () => {
 	describe( '<button> bindings', () => {
 		describe( 'class', () => {
 			it( 'is set initially', () => {
-				expect( view.element.classList.contains( 'ck-button' ) ).to.be.true( 'ck-button' );
-				expect( view.element.classList.contains( 'ck-enabled' ) ).to.be.true( 'ck-enabled' );
-				expect( view.element.classList.contains( 'ck-off' ) ).to.be.true( 'ck-off' );
+				expect( view.element.classList.contains( 'ck-button' ) ).to.be.true;
+				expect( view.element.classList.contains( 'ck-enabled' ) ).to.be.true;
+				expect( view.element.classList.contains( 'ck-off' ) ).to.be.true;
 				expect( view.element.classList.contains( 'ck-button-notext' ) ).to.be.false;
 			} );
 
 			it( 'reacts on model.isEnabled', () => {
 				model.isEnabled = false;
 
-				expect( view.element.classList.contains( 'ck-disabled' ) ).to.be.true( 'ck-disabled' );
+				expect( view.element.classList.contains( 'ck-disabled' ) ).to.be.true;
 			} );
 
 			it( 'reacts on model.isOn', () => {
 				model.isOn = true;
 
-				expect( view.element.classList.contains( 'ck-on' ) ).to.be.true( 'ck-on' );
+				expect( view.element.classList.contains( 'ck-on' ) ).to.be.true;
 			} );
 
 			it( 'reacts on model.noText', () => {


### PR DESCRIPTION
Fixes #21 
Related to: https://github.com/ckeditor/ckeditor5-theme-lark/pull/15

Added parameter `noText` to `Buttonview`.

**Note:**
Wrapping button text by `span` changed vertical-aling of button content a bit.
![jun-23-2016 14-31-51](https://cloud.githubusercontent.com/assets/1057056/16303145/7389e994-394f-11e6-9148-c78bce6c107b.gif)
