### PR TITLE
t/45: Renamed toolbar collection 'buttons' to 'items' for better semantics.

### DIFF
--- a/src/toolbar/toolbar.js
+++ b/src/toolbar/toolbar.js
@@ -28,6 +28,6 @@ export default class Toolbar extends Controller {
 	constructor( model, view ) {
 		super( model, view );
 
-		this.addCollection( 'buttons' );
+		this.addCollection( 'items' );
 	}
 }

--- a/src/toolbar/toolbarview.js
+++ b/src/toolbar/toolbarview.js
@@ -28,6 +28,6 @@ export default class ToolbarView extends View {
 			}
 		} );
 
-		this.register( 'buttons', el => el );
+		this.register( 'items', el => el );
 	}
 }

--- a/tests/toolbar/toolbar.js
+++ b/tests/toolbar/toolbar.js
@@ -25,7 +25,7 @@ describe( 'Toolbar', () => {
 		} );
 
 		it( 'creates buttons collection', () => {
-			expect( toolbar.collections.get( 'buttons' ) ).to.be.instanceof( ControllerCollection );
+			expect( toolbar.collections.get( 'items' ) ).to.be.instanceof( ControllerCollection );
 		} );
 	} );
 } );

--- a/tests/toolbar/toolbarview.js
+++ b/tests/toolbar/toolbarview.js
@@ -24,9 +24,9 @@ describe( 'ToolbarView', () => {
 		} );
 	} );
 
-	describe( 'buttons region', () => {
+	describe( 'items region', () => {
 		it( 'is bound to the main element', () => {
-			expect( view.regions.get( 'buttons' ).element ).to.equal( view.element );
+			expect( view.regions.get( 'items' ).element ).to.equal( view.element );
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #45.
