### PR TITLE
Fixed incorrect BalloonPanel position on Safari.

### DIFF
--- a/src/balloonpanel/balloonpanelview.js
+++ b/src/balloonpanel/balloonpanelview.js
@@ -276,8 +276,9 @@ class AbsoluteDomRect {
  */
 function getAbsoluteRect( elementOrRangeOrRect ) {
 	if ( elementOrRangeOrRect instanceof HTMLElement || elementOrRangeOrRect instanceof Range ) {
-		const elementRect = elementOrRangeOrRect.getBoundingClientRect();
 		const bodyRect = document.body.getBoundingClientRect();
+		const elementRect = elementOrRangeOrRect instanceof Range && elementOrRangeOrRect.collapsed ?
+			elementOrRangeOrRect.getClientRects()[ 0 ] : elementOrRangeOrRect.getBoundingClientRect();
 
 		return {
 			top: elementRect.top - bodyRect.top,

--- a/tests/tickets/90/1.html
+++ b/tests/tickets/90/1.html
@@ -1,0 +1,8 @@
+<head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">
+</head>
+
+<div id="editor">
+    <p>Put empty selection anywhere here.</p>
+</div>

--- a/tests/tickets/90/1.js
+++ b/tests/tickets/90/1.js
@@ -1,0 +1,40 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
+import Model from '/ckeditor5/ui/model.js';
+import BalloonPanel from '/ckeditor5/ui/balloonpanel/balloonpanel.js';
+import BalloonPanelView from '/ckeditor5/ui/balloonpanel/balloonpanelview.js';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	features: [ 'enter', 'typing', 'heading' ],
+	toolbar: [ 'headings' ]
+} )
+.then( editor => {
+	window.editor = editor;
+
+	const document = editor.editing.view;
+	const selection = document.selection;
+	const domEditableElement = document.domConverter.getCorrespondingDomElement( document.selection.editableElement );
+	const balloonPanel = new BalloonPanel( new Model(), new BalloonPanelView() );
+
+	editor.ui.add( 'body', balloonPanel );
+
+	document.on( 'render', () => {
+		if ( selection.isCollapsed ) {
+			balloonPanel.view.attachTo(
+				document.domConverter.viewRangeToDom( document.selection.getFirstRange() ),
+				domEditableElement
+			);
+		} else {
+			balloonPanel.view.hide();
+		}
+	} );
+} )
+.catch( err => {
+	console.error( err.stack );
+} );

--- a/tests/tickets/90/1.md
+++ b/tests/tickets/90/1.md
@@ -1,0 +1,6 @@
+@bender-ui: collapsed
+@bender-tags: ticket, 90, 0.3.0, iteration3
+
+### Manual test for ticket [#90](https://github.com/ckeditor/ckeditor5-ui-default/issues/90)
+
+Put empty selection anywhere in the editor and check if balloon panel, attached to selection appeared.  


### PR DESCRIPTION
Fixes #90 and https://github.com/ckeditor/ckeditor5-link/issues/46.

Check [manual Test](http://localhost:1030/build/modules/amd/tests/ui-default/tickets/90/1).
