### PR TITLE
t/127: Use drop shadow for StickyToolbarView when sticky.

### DIFF
--- a/theme/components/stickytoolbar.scss
+++ b/theme/components/stickytoolbar.scss
@@ -3,6 +3,8 @@
 
 @include ck-editor {
 	.ck-toolbar.ck-toolbar_sticky {
+		@include ck-dropshadow();
+
 		position: fixed;
 		top: 0;
 		border: 1px solid ck-border-color();


### PR DESCRIPTION
Closes #127.

Before
![image](https://cloud.githubusercontent.com/assets/1099479/20561199/9c3efc20-b17d-11e6-9a03-8937a6c02c54.png)

After 
![image](https://cloud.githubusercontent.com/assets/1099479/20561188/8a313296-b17d-11e6-8f23-b6fd7e911a57.png)
