### PR TITLE
t/62: Enabled rich tooltips in the ButtonView.

### DIFF
--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -101,9 +101,9 @@ export default class ButtonView extends View {
 		 * @see #title
 		 * @private
 		 * @observable
-		 * @member {Boolean} #_title
+		 * @member {Boolean} #_tooltip
 		 */
-		this.bind( '_title' ).to( this, 'title', this, 'label', this, 'keystroke', this._getTitle.bind( this ) );
+		this.bind( '_tooltip' ).to( this, 'title', this, 'label', this, 'keystroke', this._getTooltip.bind( this ) );
 
 		/**
 		 * Icon of the button view.
@@ -120,14 +120,15 @@ export default class ButtonView extends View {
 			attributes: {
 				class: [
 					'ck-button',
+					'ck-tooltip_s',
 					bind.to( 'isEnabled', value => value ? 'ck-enabled' : 'ck-disabled' ),
 					bind.to( 'isOn', value => value ? 'ck-on' : 'ck-off' ),
 					bind.if( 'withText', 'ck-button_with-text' )
 				],
-				title: [
-					bind.to( '_title' )
-				],
-				type: bind.to( 'type', value => value ? value : 'button' )
+				type: bind.to( 'type', value => value ? value : 'button' ),
+				'data-ck-tooltip': [
+					bind.to( '_tooltip' )
+				]
 			},
 
 			children: [
@@ -193,7 +194,7 @@ export default class ButtonView extends View {
 	}
 
 	/**
-	 * Gets value for DOM title attribute from title, label and keystroke properties.
+	 * Gets value for the `data-ck-tooltip` attribute from title, label and keystroke properties.
 	 *
 	 * @private
 	 * @param {String} title Button title.
@@ -201,7 +202,7 @@ export default class ButtonView extends View {
 	 * @param {String} keystroke Button keystroke.
 	 * @returns {String}
 	 */
-	_getTitle( title, label, keystroke ) {
+	_getTooltip( title, label, keystroke ) {
 		if ( title ) {
 			return title;
 		}

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -69,7 +69,7 @@ describe( 'ButtonView', () => {
 
 		describe( 'tooltip', () => {
 			it( 'is not initially set ', () => {
-				expect( view.element.attributes[ 'data-ck-tooltip' ] ).to.undefined;
+				expect( view.element.dataset.ckTooltip ).to.undefined;
 			} );
 
 			it( 'is always equal to view#title if is defined', () => {
@@ -77,20 +77,20 @@ describe( 'ButtonView', () => {
 				view.label = 'foo';
 				view.keystroke = 'A';
 
-				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar' );
+				expect( view.element.dataset.ckTooltip ).to.equal( 'bar' );
 			} );
 
 			it( 'is equal to view#label when view#title is not defined', () => {
 				view.label = 'bar';
 
-				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar' );
+				expect( view.element.dataset.ckTooltip ).to.equal( 'bar' );
 			} );
 
 			it( 'contains keystroke when view#label and view#keystroke is defined', () => {
 				view.label = 'bar';
 				view.keystroke = 'A';
 
-				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar (A)' );
+				expect( view.element.dataset.ckTooltip ).to.equal( 'bar (A)' );
 			} );
 		} );
 

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -24,9 +24,10 @@ describe( 'ButtonView', () => {
 	describe( '<button> bindings', () => {
 		describe( 'class', () => {
 			it( 'is set initially', () => {
-				expect( view.element.classList ).to.have.length( 3 );
+				expect( view.element.classList ).to.have.length( 4 );
 				expect( view.element.classList.contains( 'ck-button' ) ).to.true;
 				expect( view.element.classList.contains( 'ck-off' ) ).to.true;
+				expect( view.element.classList.contains( 'ck-tooltip_s' ) ).to.true;
 			} );
 
 			it( 'reacts on view#isEnabled', () => {
@@ -66,9 +67,9 @@ describe( 'ButtonView', () => {
 			} );
 		} );
 
-		describe( 'title', () => {
+		describe( 'tooltip', () => {
 			it( 'is not initially set ', () => {
-				expect( view.element.attributes.title ).to.undefined;
+				expect( view.element.attributes[ 'data-ck-tooltip' ] ).to.undefined;
 			} );
 
 			it( 'is always equal to view#title if is defined', () => {
@@ -76,20 +77,20 @@ describe( 'ButtonView', () => {
 				view.label = 'foo';
 				view.keystroke = 'A';
 
-				expect( view.element.attributes.title.value ).to.equal( 'bar' );
+				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar' );
 			} );
 
 			it( 'is equal to view#label when view#title is not defined', () => {
 				view.label = 'bar';
 
-				expect( view.element.attributes.title.value ).to.equal( 'bar' );
+				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar' );
 			} );
 
 			it( 'contains keystroke when view#label and view#keystroke is defined', () => {
 				view.label = 'bar';
 				view.keystroke = 'A';
 
-				expect( view.element.attributes.title.value ).to.equal( 'bar (A)' );
+				expect( view.element.attributes[ 'data-ck-tooltip' ].value ).to.equal( 'bar (A)' );
 			} );
 		} );
 


### PR DESCRIPTION
Requires https://github.com/ckeditor/ckeditor5-theme-lark/pull/60.

Closes #62.