### PR TITLE
Aligned sticky toolbar view styles to the new Lark API.

### DIFF
--- a/theme/components/stickytoolbar.scss
+++ b/theme/components/stickytoolbar.scss
@@ -3,7 +3,7 @@
 
 @include ck-editor {
 	.ck-toolbar.ck-toolbar_sticky {
-		@include ck-dropshadow();
+		@include ck-drop-shadow();
 
 		position: fixed;
 		top: 0;


### PR DESCRIPTION
Requires https://github.com/ckeditor/ckeditor5-theme-lark/issues/62.

Closes #145.

