### PR TITLE
t/140b: Added support for inline SVG to the IconView.

### DIFF
--- a/src/button/buttonview.js
+++ b/src/button/buttonview.js
@@ -182,7 +182,7 @@ export default class ButtonView extends View {
 		if ( this.icon && !this.iconView ) {
 			const iconView = this.iconView = new IconView();
 
-			iconView.bind( 'name' ).to( this, 'icon' );
+			iconView.bind( 'content' ).to( this, 'icon' );
 
 			this.element.insertBefore( iconView.element, this.element.firstChild );
 

--- a/src/icon/iconview.js
+++ b/src/icon/iconview.js
@@ -40,20 +40,16 @@ export default class IconView extends View {
 				viewBox: '0 0 20 20'
 			}
 		} );
-	}
 
-	init() {
 		/**
 		 * This is a hack for lack of innerHTML binding.
 		 * See: https://github.com/ckeditor/ckeditor5-ui/issues/99.
 		 */
-		return super.init().then( () => {
-			this.on( 'change:content', ( evt, name, value ) => {
-				this.element.innerHTML = getIconContent( value );
-			} );
-
-			this.element.innerHTML = getIconContent( this.content );
+		this.on( 'change:content', ( evt, name, value ) => {
+			this.element.innerHTML = getIconContent( value );
 		} );
+
+		this.element.innerHTML = getIconContent( this.content );
 	}
 }
 

--- a/src/icon/iconview.js
+++ b/src/icon/iconview.js
@@ -36,7 +36,8 @@ export default class IconView extends View {
 			tag: 'svg',
 			ns: 'http://www.w3.org/2000/svg',
 			attributes: {
-				class: 'ck-icon'
+				class: 'ck-icon',
+				viewBox: '0 0 20 20'
 			}
 		} );
 	}

--- a/src/icon/iconview.js
+++ b/src/icon/iconview.js
@@ -22,36 +22,57 @@ export default class IconView extends View {
 	constructor() {
 		super();
 
-		const bind = this.bindTemplate;
+		/**
+		 * The inline SVG or in legacy mode the name of the icon
+		 * which corresponds with the name of the file in the
+		 * {@link module:theme/iconmanagermodel~IconManagerModel}.
+		 *
+		 * @observable
+		 * @member {String} #content
+		 */
+		this.set( 'content' );
 
 		this.template = new Template( {
 			tag: 'svg',
 			ns: 'http://www.w3.org/2000/svg',
 			attributes: {
-				class: [
-					'ck-icon'
-				]
-			},
-			children: [
-				{
-					tag: 'use',
-					ns: 'http://www.w3.org/2000/svg',
-					attributes: {
-						href: {
-							ns: 'http://www.w3.org/1999/xlink',
-							value: bind.to( 'name', name => `#ck-icon-${ name }` )
-						}
-					}
-				}
-			]
+				class: 'ck-icon'
+			}
 		} );
-
-		/**
-		 * The name of the icon. It corresponds with the name of the
-		 * file in the {@link module:theme/iconmanagermodel~IconManagerModel}.
-		 *
-		 * @observable
-		 * @member {String} #name
-		 */
 	}
+
+	init() {
+		/**
+		 * This is a hack for lack of innerHTML binding.
+		 * See: https://github.com/ckeditor/ckeditor5-ui/issues/99.
+		 */
+		return super.init().then( () => {
+			this.on( 'change:content', ( evt, name, value ) => {
+				this.element.innerHTML = getIconContent( value );
+			} );
+
+			this.element.innerHTML = getIconContent( this.content );
+		} );
+	}
+}
+
+// Analyzes which type of content is provided and returns it in proper format.
+//
+// Temporarily 2 types of icon content are supported:
+// * Inline SVG - content of svg file as plan text.
+// * Icon name (legacy) - name of icon corresponds with name of the file in the {@link module:theme/iconmanagermodel~IconManagerModel}.
+//
+// @param {String} content
+// @returns {String}
+function getIconContent( content ) {
+	return /</.test( content ) ? extractSvgContent( content ) : `<use xlink:href="#ck-icon-${ content }"></use>`;
+}
+
+// Extracts content which is inside <svg></svg> tag.
+// It removes new line characters and then extracts content of svg.
+//
+// @param {String} svgContent svg xml.
+// @returns {String}
+function extractSvgContent( svgContent ) {
+	return /<[svg][^>]*>(.*)<\/svg>/.exec( svgContent.replace( /\r?\n|\r/g, '' ) )[ 1 ];
 }

--- a/src/icon/iconview.js
+++ b/src/icon/iconview.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md.
  */
 
+/* global DOMParser */
+
 /**
  * @module ui/icon/iconview
  */
@@ -22,6 +24,8 @@ export default class IconView extends View {
 	constructor() {
 		super();
 
+		const bind = this.bindTemplate;
+
 		/**
 		 * The inline SVG or in legacy mode the name of the icon
 		 * which corresponds with the name of the file in the
@@ -32,44 +36,44 @@ export default class IconView extends View {
 		 */
 		this.set( 'content' );
 
+		/**
+		 * This attribute specifies the boundaries to which the
+		 * icon content should stretch.
+		 *
+		 * @observable
+		 * @default '0 0 20 20'
+		 * @member {String} #viewBox
+		 */
+		this.set( 'viewBox', '0 0 20 20' );
+
 		this.template = new Template( {
 			tag: 'svg',
 			ns: 'http://www.w3.org/2000/svg',
 			attributes: {
 				class: 'ck-icon',
-				viewBox: '0 0 20 20'
+				viewBox: bind.to( 'viewBox' )
 			}
 		} );
 
-		/**
-		 * This is a hack for lack of innerHTML binding.
-		 * See: https://github.com/ckeditor/ckeditor5-ui/issues/99.
-		 */
+		// This is a hack for lack of innerHTML binding.
+		// See: https://github.com/ckeditor/ckeditor5-ui/issues/99.
+		//
+		// Temporarily 2 types of icon content are supported:
+		//   * Inline SVG - content of svg file as plan text.
+		//   * Icon name (legacy) - name of icon corresponds with name of the
+		//     file in the {@link module:theme/iconmanagermodel~IconManagerModel}.
 		this.on( 'change:content', ( evt, name, value ) => {
-			this.element.innerHTML = getIconContent( value );
+			if ( /</.test( value ) ) {
+				const svg = new DOMParser()
+					.parseFromString( value.trim(), 'image/svg+xml' )
+					.firstChild;
+
+				while ( svg.childNodes.length > 0 ) {
+					this.element.appendChild( svg.childNodes[ 0 ] );
+				}
+			} else {
+				this.element.innerHTML = `<use xlink:href="#ck-icon-${ value }"></use>`;
+			}
 		} );
-
-		this.element.innerHTML = getIconContent( this.content );
 	}
-}
-
-// Analyzes which type of content is provided and returns it in proper format.
-//
-// Temporarily 2 types of icon content are supported:
-// * Inline SVG - content of svg file as plan text.
-// * Icon name (legacy) - name of icon corresponds with name of the file in the {@link module:theme/iconmanagermodel~IconManagerModel}.
-//
-// @param {String} content
-// @returns {String}
-function getIconContent( content ) {
-	return /</.test( content ) ? extractSvgContent( content ) : `<use xlink:href="#ck-icon-${ content }"></use>`;
-}
-
-// Extracts content which is inside <svg></svg> tag.
-// It removes new line characters and then extracts content of svg.
-//
-// @param {String} svgContent svg xml.
-// @returns {String}
-function extractSvgContent( svgContent ) {
-	return /<[svg][^>]*>(.*)<\/svg>/.exec( svgContent.replace( /\r?\n|\r/g, '' ) )[ 1 ];
 }

--- a/tests/button/buttonview.js
+++ b/tests/button/buttonview.js
@@ -147,10 +147,10 @@ describe( 'ButtonView', () => {
 				expect( view.element.childNodes[ 0 ] ).to.equal( view.iconView.element );
 
 				expect( view.iconView ).to.instanceOf( IconView );
-				expect( view.iconView.name ).to.equal( 'foo' );
+				expect( view.iconView.content ).to.equal( 'foo' );
 
 				view.icon = 'bar';
-				expect( view.iconView.name ).to.equal( 'bar' );
+				expect( view.iconView.content ).to.equal( 'bar' );
 			} );
 		} );
 

--- a/tests/icon/iconview.js
+++ b/tests/icon/iconview.js
@@ -18,6 +18,7 @@ describe( 'IconView', () => {
 		it( 'creates element from template', () => {
 			expect( view.element.tagName ).to.equal( 'svg' );
 			expect( view.element.getAttribute( 'class' ) ).to.equal( 'ck-icon' );
+			expect( view.element.getAttribute( 'viewBox' ) ).to.equal( '0 0 20 20' );
 		} );
 	} );
 

--- a/tests/icon/iconview.js
+++ b/tests/icon/iconview.js
@@ -22,15 +22,25 @@ describe( 'IconView', () => {
 	} );
 
 	describe( '<svg> bindings', () => {
-		describe( 'xlink:href', () => {
-			it( 'reacts to changes in model#name', () => {
-				const svgUseElement = view.element.firstChild;
-				const svgHrefNs = 'http://www.w3.org/1999/xlink';
+		describe( 'inline svg', () => {
+			it( 'should react to changes in view#content', () => {
+				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><g id="test"></g></svg>';
 
-				view.set( 'name', 'foo' );
+				expect( view.element.innerHTML = '<g id="test"></g>' );
+			} );
+		} );
+
+		describe( 'legacy xlink:href', () => {
+			it( 'reacts to changes in view#content', () => {
+				const svgHrefNs = 'http://www.w3.org/1999/xlink';
+				let svgUseElement;
+
+				view.content = 'foo';
+				svgUseElement = view.element.firstChild;
 				expect( svgUseElement.getAttributeNS( svgHrefNs, 'href' ) ).to.equal( '#ck-icon-foo' );
 
-				view.name = 'abc';
+				view.content = 'abc';
+				svgUseElement = view.element.firstChild;
 				expect( svgUseElement.getAttributeNS( svgHrefNs, 'href' ) ).to.equal( '#ck-icon-abc' );
 			} );
 		} );

--- a/tests/icon/iconview.js
+++ b/tests/icon/iconview.js
@@ -23,6 +23,16 @@ describe( 'IconView', () => {
 	} );
 
 	describe( '<svg> bindings', () => {
+		describe( 'viewBox', () => {
+			it( 'should react to changes in view#viewBox', () => {
+				expect( view.element.getAttribute( 'viewBox' ) ).to.equal( '0 0 20 20' );
+
+				view.viewBox = '1 2 3 4';
+
+				expect( view.element.getAttribute( 'viewBox' ) ).to.equal( '1 2 3 4' );
+			} );
+		} );
+
 		describe( 'inline svg', () => {
 			it( 'should react to changes in view#content', () => {
 				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg"><g id="test"></g></svg>';

--- a/tests/manual/icon/icon.html
+++ b/tests/manual/icon/icon.html
@@ -1,0 +1,15 @@
+<head>
+	<link rel="stylesheet" href="/theme/ckeditor.css">
+
+	<style>
+		#inline-svg li {
+			width: 150px;
+			text-align: center;
+			min-height: 60px;
+		}
+	</style>
+</head>
+
+<h2>Icons with embed SVG</h2>
+
+<ol id="inline-svg"></ol>

--- a/tests/manual/icon/icon.js
+++ b/tests/manual/icon/icon.js
@@ -1,0 +1,81 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals document */
+
+import IconView from 'ckeditor5/ui/icon/iconview.js';
+
+const wrapper = document.querySelector( '#inline-svg' );
+
+const icon = `
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg"
+ xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
+    <!-- Generator: Sketch 3.5.2 (25235) - http://www.bohemiancoding.com/sketch -->
+    <title>image</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
+        <g id="image" sketch:type="MSArtboardGroup" fill="#454545">
+            <g id="icon:image" sketch:type="MSLayerGroup" transform="translate(2.000000, 3.000000)">
+                <path d="M0,11.9941413 C0,13.1019465 0.894513756,14 1.99406028,14 L14.0059397,14 C15.1072288,14 16,13.1029399 16,11.9941413
+                 L16,2.00585866 C16,0.898053512 15.1054862,0 14.0059397,0 L1.99406028,0 C0.892771196,0 0,0.897060126 0,2.00585866 
+                 L0,11.9941413 Z M1,2.00247329 C1,1.44882258 1.44994876,1 2.00684547,1 L13.9931545,1 C14.5492199,1 15,1.45576096 
+                 15,2.00247329 L15,11.9975267 C15,12.5511774 14.5500512,13 13.9931545,13 L2.00684547,13 C1.45078007,13 1,12.544239 
+                 1,11.9975267 L1,2.00247329 Z M2.0237314,12.0028573 L14,12.0028573 L14,8.90598928 L11.1099289,4.64285714 
+                 L8.01350775,9.9000001 L5.01091767,7.79714291 L2,10.9601769 L2.0237314,12.0028573 Z M4.40625001,3 C3.62959688,3
+                  3,3.62360071 3,4.39285714 C3,5.16210429 3.62959688,5.78571429 4.40625001,5.78571429 C5.18289376,5.78571429 
+                  5.81250002,5.16210429 5.81250002,4.39285714 C5.81250002,3.62360071 5.18289376,3 4.40625001,3 L4.40625001,3 Z" 
+                  id="path4700" sketch:type="MSShapeGroup"></path>
+            </g>
+        </g>
+    </g>
+</svg>`;
+
+// Small.
+addCase( renderIcon( icon, 20 ) );
+
+// Medium.
+addCase( renderIcon( icon, 40 ) );
+
+// Large.
+addCase( renderIcon( icon, 60 ) );
+
+// Color.
+addCase( renderIcon( icon, 60, 'red' ) );
+
+// Inherited color.
+const iconWrapper = document.createElement( 'p' );
+iconWrapper.style.color = 'blue';
+iconWrapper.appendChild( document.createTextNode( 'foo' ) );
+iconWrapper.appendChild( renderIcon( icon, 60 ) );
+iconWrapper.appendChild( document.createTextNode( 'bar' ) );
+addCase( iconWrapper );
+
+function renderIcon( content, size, color ) {
+	const iconView = new IconView();
+
+	iconView.content = content;
+	iconView.init();
+
+	if ( size ) {
+		iconView.element.style.width = `${ size }px`;
+		iconView.element.style.height = `${ size }px`;
+	}
+
+	if ( color ) {
+		iconView.element.style.color = color;
+	}
+
+	return iconView.element;
+}
+
+function addCase( el ) {
+	const item = document.createElement( 'li' );
+
+	item.appendChild( el );
+
+	wrapper.appendChild( item );
+}

--- a/tests/manual/icon/icon.md
+++ b/tests/manual/icon/icon.md
@@ -1,0 +1,7 @@
+## Icons with inline SVG
+
+1. First icon should be small size and dark color.
+1. Second icon should be medium size and dark color.
+1. Third icon should be large size and dark color.
+1. Fourth icon should be large size and red color.
+1. Fifth icon should be large size and blue color (inherited).


### PR DESCRIPTION
Closes #140.

This PR extends https://github.com/ckeditor/ckeditor5-ui-default/pull/141. Despite the performance drop, for the sake of readability, I'm definitely for the `DOMParser`. It is clean and safe. If we ever need to import some attributes or convert some content in the SVG string, it shouldn't be done by RegExp. If you have a problem and use RegExp, then usually you have 2 problems, that's why. Besides, the process of converting the SVG string into DOM is async to the main editor initialization so I wouldn't bother with performance – how many icons will be used? 10? 20?

I also created the `IconView#viewBox` attribute. The viewBox may change, depending on the icon being used, so there must be a way to configure it. I guess that in the next iteration we may even import it automatically from the SVG string with some fallback value.